### PR TITLE
update minimal flutter sdk to 2.2.0 (#13)

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -6,6 +6,7 @@ repository: https://github.com/hoc081098/flutter_google_places
 
 environment:
   sdk: '>=2.12.0 <3.0.0'
+  flutter: ^2.2.0
 
 dependencies:
   flutter:


### PR DESCRIPTION
* update minimal flutter sdk to 2.2.0

I was using flutter 2.0.6 and using `flutter_google_places_hoc081098: ^1.0.0-nullsafety.4`. When run the app, I encountered error 
```
../../.pub-cache/hosted/pub.dartlang.org/flutter_google_places_hoc081098-1.0.0-nullsafety.4/lib/src/flutter_google_places.dart:261:9: Error: No named parameter with the name 'color'.
            color: Theme.of(context).colorScheme.secondary,
            ^^^^^
    ../../SDKs/flutold/packages/flutter/lib/src/material/progress_indicator.dart:304:9: Context: Found this candidate, but the arguments don't match.
      const LinearProgressIndicator({
            ^^^^^^^^^^^^^^^^^^^^^^^
```

I did some research that this parameter was added to flutter version 2.2.0 https://flutter.dev/docs/development/tools/sdk/release-notes

* add flutter sdk constraints

* fix wrong version number